### PR TITLE
refatora: usa gerador para a url e arquivos

### DIFF
--- a/src/baixar_arquivos.py
+++ b/src/baixar_arquivos.py
@@ -8,13 +8,19 @@ def baixar_arquivo(url, endereco):
     if resposta.status_code == requests.codes.OK:
         with open(endereco, 'wb') as novo_arquivo:
             novo_arquivo.write(resposta.content)
-        print("Donwload finalizado. Salvo em: {}".format(endereco))
+        print("Download finalizado. Salvo em: {}".format(endereco))
     else:
         resposta.raise_for_status()
 
+def gerar_enderecos(sequencia, url_base, arquivo_base, dir_saida = 'output'):
+    # gera a sequencia de urls e nomes de arquivo
+    for i in sequencia:
+        url = url_base.format(i)
+        nome_arquivo = os.path.join(dir_saida, arquivo_base.format(i))
+        yield (url, nome_arquivo)
+
 if __name__ == "__main__":
-    BASE_URL = 'https://math.mit.edu/classes/18.745/Notes/Lecture_{}_Notes.pdf'
-    OUTPUT_DIR = 'output'
-    for i in range(1, 26):
-        nome_arquivo = os.path.join(OUTPUT_DIR, 'nota_de_aula_{}.pdf'.format(i))
-        baixar_arquivo(BASE_URL.format(i), nome_arquivo)
+    url_base = 'https://math.mit.edu/classes/18.745/Notes/Lecture_{}_Notes.pdf'
+    arquivo_base = 'nota_de_aula_{}.pdf'
+    for (url, nome_arquivo) in gerar_enderecos(range(1, 26), url_base, arquivo_base):
+        baixar_arquivo(url, nome_arquivo)


### PR DESCRIPTION
Olá pessoal do Programação Dinâmica,

Acabei de ver o [Python na Prática #02](https://www.youtube.com/watch?v=qx2LGtKzjxk) no Youtube e deu vontade de sugerir uma pequena alteração no código. Não sei se pretendem aceitar PRs nesse repositório, mas aproveito esse mecanismo para iniciar o diálogo :) Sintam-se livres para recusar o merge haha

Nesse commit eu extraí um gerador para isolar a lógica de gerar os nomes. É claro que a necessidade disso é discutível, dado que a complexidade do gerador ainda é baixa. Mesmo assim acho que é um exemplo interessante de como introduzir o conceito do gerador, e como ficaria mais fácil incrementá-lo (separando arquivos em diretórios por algum critério, por exemplo) uma vez que esse código está contido na função separada. Pode ser um passo em direção a aceitar parâmetros pela linha de comando como sugeriu o Hallison. Abraço!